### PR TITLE
Packaging updates

### DIFF
--- a/dmlib/interf.py
+++ b/dmlib/interf.py
@@ -4,7 +4,10 @@
 import numpy as np
 from numpy.fft import fft, fftshift, ifft
 from numpy.linalg import norm
-from scipy.signal import tukey
+try:
+    from scipy.signal import tukey
+except ImportError:
+    from scipy.signal.windows import tukey
 from skimage import measure, morphology
 from skimage.restoration import unwrap_phase
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,15 @@
 name: dmlib
 
 dependencies:
-  - python=3
-  - numpy
+  - python
+  - numpy<2
   - h5py
   - matplotlib
   - scikit-image
-  - cython
+  - cython<3
+  - pip:
+    - pyqt5
 
 channels:
+  - conda-forge
   - anaconda


### PR DESCRIPTION
Some fixes to work with newer Python packages, and to forbid use of `numpy` 2.0. Also adds the required package `pyqt5`.